### PR TITLE
Add jshint-stylish to improve JSHint output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,6 +198,7 @@ module.exports = function(grunt) {
     },
     jshint: {
       options: {
+        reporter: require('jshint-stylish'),
         jshintrc: '.jshintrc'
       },
       gruntfile: ['Gruntfile.js'],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-ftpscript": "~0.1.7",
     "grunt-newer": "~0.6.0",
     "grunt-svgmin": "~0.3.0",
-    "load-grunt-tasks": "~0.2.1"
+    "load-grunt-tasks": "~0.2.1",
+    "jshint-stylish": "~0.1.5"
   }
 }


### PR DESCRIPTION
Very simple addition (deliberately not wanting to mess with the existing workflow).

This introduces [jshint-stylish](https://www.npmjs.org/package/jshint-stylish) to tidy JSHint output. For example, from: 

``` bash
$ grunt jshint

Running "jshint:all" (jshint) task
Linting src/assets/scripts/core.js ...ERROR
[L56:C5] E022: Line breaking error 'return'.
    return
[L56:C11] W033: Missing semicolon.
    return
[L58:C16] W004: 'name' is already defined.
        name : name
[L58:C16] W028: Label 'name' on name statement.
        name : name
[L58:C16] W037: 'name' is a statement label.
        name : name
[L58:C16] W030: Expected an assignment or function call and instead saw an expression.
        name : name
[L58:C20] W033: Missing semicolon.
        name : name
[L59:C6] W032: Unnecessary semicolon.
    };
[L53:C1] W117: 'foo' is not defined.
foo = 3; // NO!

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.
```

To:

``` bash
$ grunt jshint

Running "jshint:all" (jshint) task

src/assets/scripts/core.js
  line 56  col 5   Line breaking error 'return'.
  line 56  col 11  Missing semicolon.
  line 58  col 16  'name' is already defined.
  line 58  col 16  Label 'name' on name statement.
  line 58  col 16  'name' is a statement label.
  line 58  col 16  Expected an assignment or function call and instead saw an expression.
  line 58  col 20  Missing semicolon.
  line 59  col 6   Unnecessary semicolon.
  line 53  col 1   'foo' is not defined.

✖ 9 problems

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.
```
